### PR TITLE
chore: align VS Code configuration with Rstack

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,4 @@
 {
   "search.useIgnoreFiles": true,
-  "[json]": {
-    "editor.defaultFormatter": "rstack.rstack"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "rstack.rstack"
-  },
-  "[javascript]": {
-    "editor.defaultFormatter": "rstack.rstack"
-  },
-  "[javascriptreact]": {
-    "editor.defaultFormatter": "rstack.rstack"
-  },
-  "[css]": {
-    "editor.defaultFormatter": "rstack.rstack"
-  }
+  "editor.defaultFormatter": "rstack.rstack"
 }


### PR DESCRIPTION
VS Code configures Rstack only for a few languages. Use the repository-wide default from rsbuild-plugin-template so other supported files use the same formatter.